### PR TITLE
Added webp to the allowed image types.

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -29,7 +29,7 @@ function updateCurrentPath() {
 publish.registerMarkdownPostProcessor(async (el, ctx) => {
   updateCurrentPath();
 
-  const blockImages = Array.from(el.querySelectorAll('.internal-embed')).filter(span => /\.(jpg|jpeg|png|gif|bmp|svg)$/i.test(span.getAttribute('src')));
+  const blockImages = Array.from(el.querySelectorAll('.internal-embed')).filter(span => /\.(jpg|jpeg|png|gif|bmp|svg|webp)$/i.test(span.getAttribute('src')));
   blockImages.forEach((span) => {
     if (!span.classList.contains('processed')) {
       span.classList.add('processed');


### PR DESCRIPTION
I'm using the format WebP to compress images in my Obsidian vault. Adding the format here allows the lightbox to work with these images too. For context: I'm using the Obsidian plugin "Image Converter" to automatically convert images to save storage in my vault. More details about WebP can be found here https://en.wikipedia.org/wiki/WebP